### PR TITLE
CI: add `codecov.yml` to relax patch coverage threshold to 98%

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,15 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+    patch:
+      default:
+        target: 98%
+        threshold: 1%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: false


### PR DESCRIPTION
### Motivation
- PR coverage checks were blocking merges because the default Codecov patch target is stricter than intended; a repository-level `codecov.yml` lets CI enforce a practical patch threshold and clearer comment behavior.

### Description
- Add `codecov.yml` at repo root that sets project status `target` to `auto` with `threshold: 1%` and sets `coverage.status.patch.default.target` to `98%` with `threshold: 1%`.
- Configure Codecov comment layout and behavior via the `comment` section so PR feedback includes reach/diff/flags/files.
- Commit the new `codecov.yml` file to the repository.

### Testing
- Attempted to run `flutter test --coverage` in this environment but it failed because `flutter` is not installed, so coverage generation could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b435778b288332bd49b1372e79dc31)